### PR TITLE
Opravení redirectu do aplikace ČS Identity

### DIFF
--- a/core/src/main/java/cz/csas/cscore/locker/Constants.java
+++ b/core/src/main/java/cz/csas/cscore/locker/Constants.java
@@ -42,4 +42,9 @@ public class Constants {
      * The constant OAUTH_REQUEST_CODE.
      */
     public static final int OAUTH_REQUEST_CODE = 100;
+
+    /**
+     * The constant CS_IDENTITA_REDIRECT_URL_EXTRA.
+     */
+    public static final String CS_IDENTITA_REDIRECT_URL_EXTRA = "cs_identita_redirect_url_extra";
 }

--- a/core/src/main/java/cz/csas/cscore/locker/LockerConfig.java
+++ b/core/src/main/java/cz/csas/cscore/locker/LockerConfig.java
@@ -23,19 +23,21 @@ public class LockerConfig {
      */
     private String clientId;
     private String clientSecret;
+    private String csIdentitaRedirectUrl;
     private String redirectUrl;
     private String scope;
     private String publicKey;
     private boolean offlineAuthEnabled = false;
     private Environment environment;
 
-    private LockerConfig(String clientId, String clientSecret, String redirectUrl, String scope, String publicKey, boolean offlineAuthEnabled) {
+    private LockerConfig(String clientId, String clientSecret, String redirectUrl, String scope, String publicKey, boolean offlineAuthEnabled, String csIdentitaRedirectUrl) {
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.redirectUrl = redirectUrl;
         this.scope = scope;
         this.publicKey = publicKey;
         this.offlineAuthEnabled = offlineAuthEnabled;
+        this.csIdentitaRedirectUrl = csIdentitaRedirectUrl;
     }
 
     /**
@@ -110,6 +112,17 @@ public class LockerConfig {
         this.environment = environment;
     }
 
+
+    /**
+     * Gets CS Identita redirect url.
+     *
+     * @return the CS Identita redirect url.
+     */
+    public String getCsIdentitaRedirectUrl() {
+        return csIdentitaRedirectUrl;
+    }
+
+
     /**
      * The type Builder.
      */
@@ -118,6 +131,8 @@ public class LockerConfig {
         private String clientId;
 
         private String clientSecret;
+
+        private String csIdentitaRedirectUrl;
 
         private String redirectUrl;
 
@@ -193,12 +208,24 @@ public class LockerConfig {
         }
 
         /**
+
+         * Sets CS Identita redirect url.
+         *
+         * @param csIdentitaRedirectUrl the CS Identita redirect url.
+         */
+        public  Builder setCsIdentitaRedirectUrl(String csIdentitaRedirectUrl) {
+            this.csIdentitaRedirectUrl = csIdentitaRedirectUrl;
+            return this;
+        }
+
+
+        /**
          * Create locker config.
          *
          * @return the locker config
          */
         public LockerConfig create() {
-            return new LockerConfig(clientId, clientSecret, redirectUrl, scope, publicKey, offlineAuthEnabled);
+            return new LockerConfig(clientId, clientSecret, redirectUrl, scope, publicKey, offlineAuthEnabled, csIdentitaRedirectUrl);
         }
 
 

--- a/core/src/main/java/cz/csas/cscore/locker/LockerImpl.java
+++ b/core/src/main/java/cz/csas/cscore/locker/LockerImpl.java
@@ -605,6 +605,7 @@ class LockerImpl implements Locker {
                 Intent intent = new Intent(context, OAuthLoginActivity.class);
                 intent.putExtra(Constants.OAUTH_LOGIN_ACTIVITY_OPTIONS_EXTRA, mCsJson.toJson(mOAuthLoginActivityOptions));
                 intent.putExtra(Constants.OAUTH_URL_EXTRA, url);
+                intent.putExtra(Constants.CS_IDENTITA_REDIRECT_URL_EXTRA, mLockerConfig.getCsIdentitaRedirectUrl());
                 intent.putExtra(Constants.TESTING_JS_EXTRA, mJavascript);
                 intent.putExtra(Constants.REDIRECT_URL_EXTRA, mLockerConfig.getRedirectUrl());
                 intent.putExtra(Constants.ALLOW_UNTRUSTED_CERTIFICATES_EXTRA, getConfigManager().getEnvironment().isAllowUntrustedCertificates());

--- a/core/src/main/java/cz/csas/cscore/locker/OAuthLoginActivity.java
+++ b/core/src/main/java/cz/csas/cscore/locker/OAuthLoginActivity.java
@@ -48,6 +48,7 @@ public class OAuthLoginActivity extends Activity {
     private ProgressBar mProgressBar;
     private String mUrlPath;
     private String mRedirectUrl;
+    private String mCSIdentitaRedirectUrl;
     private String mJavascript;
     private OAuthLoginActivityOptions mOAuthLoginActivityOptions;
     private boolean mAllowUntrustedCertificates;
@@ -71,6 +72,7 @@ public class OAuthLoginActivity extends Activity {
         Bundle extras = getIntent().getExtras();
         mUrlPath = extras.getString(Constants.OAUTH_URL_EXTRA);
         mRedirectUrl = extras.getString(Constants.REDIRECT_URL_EXTRA);
+        mCSIdentitaRedirectUrl = extras.getString(Constants.CS_IDENTITA_REDIRECT_URL_EXTRA);
         mJavascript = extras.getString(Constants.TESTING_JS_EXTRA);
         mOAuthLoginActivityOptions = new CsJson().fromJson(extras.getString(Constants.OAUTH_LOGIN_ACTIVITY_OPTIONS_EXTRA), OAuthLoginActivityOptions.class);
         mAllowUntrustedCertificates = extras.getBoolean(Constants.ALLOW_UNTRUSTED_CERTIFICATES_EXTRA);
@@ -92,7 +94,17 @@ public class OAuthLoginActivity extends Activity {
 
         mLoginWebView.setWebViewClient(new WebViewClient() {
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
-                if (url.startsWith(mRedirectUrl)) {
+                if (url.contains(mCSIdentitaRedirectUrl)) {
+                    Bundle bundle = new Bundle();
+                    bundle.putString(Constants.CODE_EXTRA, url);
+                    Intent intent = new Intent();
+                    intent.setAction("android.intent.action.VIEW");
+                    intent.addCategory("android.intent.category.BROWSABLE");
+                    intent.setData(Uri.parse(url));
+                    startActivity(intent);
+                    setResult(RESULT_OK, intent);
+
+                } else if(url.startsWith(mRedirectUrl)) {
                     Bundle bundle = new Bundle();
                     bundle.putString(Constants.CODE_EXTRA, url);
                     Intent resultIntent = new Intent();

--- a/core/src/main/java/cz/csas/cscore/locker/OAuthLoginActivity.java
+++ b/core/src/main/java/cz/csas/cscore/locker/OAuthLoginActivity.java
@@ -102,7 +102,6 @@ public class OAuthLoginActivity extends Activity {
                     intent.addCategory("android.intent.category.BROWSABLE");
                     intent.setData(Uri.parse(url));
                     startActivity(intent);
-                    setResult(RESULT_OK, intent);
 
                 } else if(url.startsWith(mRedirectUrl)) {
                     Bundle bundle = new Bundle();


### PR DESCRIPTION
Řešili jsme problém při migraci interních aplikací na ADFS, že z webview na androidu se neredirectovalo do ČS Identity (autorizační aplikace), ale odkazoval na errorovou webovou stránku i když byla aplikace na zařízení nainstaována. 

Po této úpravě nám stačí do configu nastavit redirect url pro ČS Identitu a uživatele to do aplikace redirectne.